### PR TITLE
Changed binning default to mean

### DIFF
--- a/microAO/aoAlg.py
+++ b/microAO/aoAlg.py
@@ -77,7 +77,7 @@ class AdaptiveOpticsFunctions():
         return self.mask
 
 
-    def bin_ndarray(self, ndarray, new_shape, operation='sum'):
+    def bin_ndarray(self, ndarray, new_shape, operation='mean'):
         """
 
         Function acquired from Stack Overflow: https://stackoverflow.com/a/29042041. Stack Overflow or other Stack Exchange


### PR DESCRIPTION
Previously the default in bin_ndarray was "sum". This is a problem for direct wavefront sensing techniques where the RMS deformation is used as a threshold as it adds in an unaccounted for scaling factor. This should also be added to the PyPI version ASAP.